### PR TITLE
feat: implementation of arff file stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,269 @@
 version = 4
 
 [[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "naive-bayes-hoeffding-trees-rust-implementation"
 version = "0.1.0"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+tempfile = "3.20.0"

--- a/src/core/attributes/attribute.rs
+++ b/src/core/attributes/attribute.rs
@@ -1,0 +1,12 @@
+use std::any::Any;
+use std::sync::Arc;
+
+pub type AttributeRef = Arc<dyn Attribute + Send + Sync>;
+
+pub trait Attribute: Any + Send + Sync {
+    fn name(&self) -> String;
+
+    fn as_any(&self) -> &dyn Any;
+
+    fn arff_representation(&self) -> String;
+}

--- a/src/core/attributes/mod.rs
+++ b/src/core/attributes/mod.rs
@@ -1,0 +1,8 @@
+mod attribute;
+mod nominal_attribute;
+mod numeric_attribute;
+
+pub use attribute::Attribute;
+pub use attribute::AttributeRef;
+pub use nominal_attribute::NominalAttribute;
+pub use numeric_attribute::NumericAttribute;

--- a/src/core/attributes/nominal_attribute.rs
+++ b/src/core/attributes/nominal_attribute.rs
@@ -1,47 +1,8 @@
+use crate::core::attributes::Attribute;
 use std::any::Any;
 use std::collections::HashMap;
 
-pub trait Attribute: Any {
-    fn name(&self) -> String;
-
-    fn as_any(&self) -> &dyn Any;
-
-    fn arff_representation(&self) -> String;
-}
-
-pub struct NumericAttribute {
-    pub name: String,
-    pub values: Vec<u32>,
-}
-
-impl NumericAttribute {
-    pub fn new(name: String) -> NumericAttribute {
-        NumericAttribute {
-            name,
-            values: Vec::new(),
-        }
-    }
-
-    pub fn with_values(name: String, values: Vec<u32>) -> NumericAttribute {
-        NumericAttribute { name, values }
-    }
-}
-
-impl Attribute for NumericAttribute {
-    fn name(&self) -> String {
-        self.name.clone()
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn arff_representation(&self) -> String {
-        let numeric = self.as_any().downcast_ref::<NumericAttribute>().unwrap();
-        format!("@attribute {} numeric", numeric.name())
-    }
-}
-
+#[derive(Clone)]
 pub struct NominalAttribute {
     pub name: String,
     pub values: Vec<String>,

--- a/src/core/attributes/numeric_attribute.rs
+++ b/src/core/attributes/numeric_attribute.rs
@@ -1,0 +1,36 @@
+use crate::core::attributes::Attribute;
+use std::any::Any;
+
+#[derive(Clone)]
+pub struct NumericAttribute {
+    pub name: String,
+    pub values: Vec<u32>,
+}
+
+impl NumericAttribute {
+    pub fn new(name: String) -> NumericAttribute {
+        NumericAttribute {
+            name,
+            values: Vec::new(),
+        }
+    }
+
+    pub fn with_values(name: String, values: Vec<u32>) -> NumericAttribute {
+        NumericAttribute { name, values }
+    }
+}
+
+impl Attribute for NumericAttribute {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn arff_representation(&self) -> String {
+        let numeric = self.as_any().downcast_ref::<NumericAttribute>().unwrap();
+        format!("@attribute {} numeric", numeric.name())
+    }
+}

--- a/src/core/instance_header.rs
+++ b/src/core/instance_header.rs
@@ -1,15 +1,16 @@
-use crate::attribute::Attribute;
+use crate::core::attributes::{Attribute, AttributeRef, NominalAttribute};
+use std::fmt;
 
 pub struct InstanceHeader {
     pub relation_name: String,
-    pub attributes: Vec<Box<dyn Attribute>>,
+    pub attributes: Vec<AttributeRef>,
     pub class_index: usize,
 }
 
 impl InstanceHeader {
     pub fn new(
         relation_name: String,
-        attributes: Vec<Box<dyn Attribute>>,
+        attributes: Vec<AttributeRef>,
         class_index: usize,
     ) -> InstanceHeader {
         InstanceHeader {
@@ -56,11 +57,21 @@ impl InstanceHeader {
         if self.class_index < self.attributes.len() {
             if let Some(nominal_attr) = self.attributes[self.class_index]
                 .as_any()
-                .downcast_ref::<crate::attribute::NominalAttribute>()
+                .downcast_ref::<NominalAttribute>()
             {
                 return nominal_attr.values.len();
             }
         }
         0
+    }
+}
+
+impl fmt::Debug for InstanceHeader {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InstanceHeader")
+            .field("relation_name", &self.relation_name)
+            .field("class_index", &self.class_index)
+            .field("n_attributes", &self.attributes.len())
+            .finish()
     }
 }

--- a/src/core/instances/dense_instance.rs
+++ b/src/core/instances/dense_instance.rs
@@ -1,45 +1,17 @@
-use crate::attribute::{Attribute, NominalAttribute, NumericAttribute};
-use crate::instance_header::InstanceHeader;
+use crate::core::attributes::{Attribute, NominalAttribute, NumericAttribute};
+use crate::core::instance_header::InstanceHeader;
+use crate::core::instances::instance::Instance;
 use std::io::Error;
-
-pub trait Instance {
-    fn weight(&self) -> f64;
-
-    fn set_weight(&mut self, new_value: f64) -> Result<(), Error>;
-
-    fn value_at_index(&self, index: usize) -> Option<f64>;
-
-    fn set_value_at_index(&mut self, index: usize, new_value: f64) -> Result<(), Error>;
-
-    fn is_missing_at_index(&self, index: usize) -> Result<bool, Error>;
-
-    fn attribute_at_index(&self, index: usize) -> Option<&dyn Attribute>;
-
-    fn index_of_attribute(&self, attribute: &dyn Attribute) -> Option<usize>;
-
-    fn class_index(&self) -> usize;
-
-    fn class_value(&self) -> Option<f64>;
-
-    fn set_class_value(&mut self, new_value: f64) -> Result<(), Error>;
-
-    fn is_class_missing(&self) -> bool;
-
-    fn number_of_classes(&self) -> usize;
-
-    fn to_vec(&self) -> Vec<f64>;
-
-    fn header(&self) -> &InstanceHeader;
-}
+use std::sync::Arc;
 
 pub struct DenseInstance {
-    pub header: &'static InstanceHeader,
+    pub header: Arc<InstanceHeader>,
     pub values: Vec<f64>,
     pub weight: f64,
 }
 
 impl DenseInstance {
-    pub fn new(header: &'static InstanceHeader, values: Vec<f64>, weight: f64) -> DenseInstance {
+    pub fn new(header: Arc<InstanceHeader>, values: Vec<f64>, weight: f64) -> DenseInstance {
         DenseInstance {
             header,
             values,
@@ -159,6 +131,6 @@ impl Instance for DenseInstance {
     }
 
     fn header(&self) -> &InstanceHeader {
-        self.header
+        &self.header
     }
 }

--- a/src/core/instances/instance.rs
+++ b/src/core/instances/instance.rs
@@ -1,0 +1,33 @@
+use crate::core::attributes::Attribute;
+use crate::core::instance_header::InstanceHeader;
+use std::io::Error;
+
+pub trait Instance {
+    fn weight(&self) -> f64;
+
+    fn set_weight(&mut self, new_value: f64) -> Result<(), Error>;
+
+    fn value_at_index(&self, index: usize) -> Option<f64>;
+
+    fn set_value_at_index(&mut self, index: usize, new_value: f64) -> Result<(), Error>;
+
+    fn is_missing_at_index(&self, index: usize) -> Result<bool, Error>;
+
+    fn attribute_at_index(&self, index: usize) -> Option<&dyn Attribute>;
+
+    fn index_of_attribute(&self, attribute: &dyn Attribute) -> Option<usize>;
+
+    fn class_index(&self) -> usize;
+
+    fn class_value(&self) -> Option<f64>;
+
+    fn set_class_value(&mut self, new_value: f64) -> Result<(), Error>;
+
+    fn is_class_missing(&self) -> bool;
+
+    fn number_of_classes(&self) -> usize;
+
+    fn to_vec(&self) -> Vec<f64>;
+
+    fn header(&self) -> &InstanceHeader;
+}

--- a/src/core/instances/mod.rs
+++ b/src/core/instances/mod.rs
@@ -1,0 +1,5 @@
+pub mod dense_instance;
+pub mod instance;
+
+pub use dense_instance::DenseInstance;
+pub use instance::Instance;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,0 +1,3 @@
+pub mod attributes;
+pub mod instance_header;
+pub mod instances;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
-mod attribute;
-mod instance;
-mod instance_header;
-mod stream;
+mod core;
+mod streams;
+mod utils;
 
 fn main() {
     println!("Hello, world!");

--- a/src/streams/arff/arff_file_stream.rs
+++ b/src/streams/arff/arff_file_stream.rs
@@ -1,0 +1,240 @@
+use crate::core::instance_header::InstanceHeader;
+use crate::core::instances::{DenseInstance, Instance};
+use crate::streams::stream::Stream;
+
+use crate::streams::arff::parser::{is_comment_or_empty, parse_header, parse_instance_values};
+use std::fs::File;
+use std::io::{BufRead, BufReader, Error, Seek, SeekFrom};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct ArffFileStream {
+    path: PathBuf,
+    reader: BufReader<File>,
+    header: Arc<InstanceHeader>,
+    data_start_pos: u64,
+    next_line: Option<String>,
+    finished: bool,
+}
+
+impl Stream for ArffFileStream {
+    fn header(&self) -> &InstanceHeader {
+        &self.header
+    }
+
+    fn has_more_instances(&self) -> bool {
+        !self.finished
+    }
+
+    fn next_instance(&mut self) -> Option<Box<dyn Instance>> {
+        if self.finished {
+            return None;
+        }
+
+        let line = self.next_line.take()?;
+        if let Err(_) = self.fill_next_line() {
+            self.finished = true;
+        }
+
+        match parse_instance_values(&self.header, &line) {
+            Ok(values) => {
+                let inst = DenseInstance::new(Arc::clone(&self.header), values, 1.0);
+                Some(Box::new(inst) as Box<dyn Instance>)
+            }
+            Err(e) => {
+                eprintln!("Invalid data found in line '{line}': {e}");
+                self.next_instance()
+            }
+        }
+    }
+
+    fn restart(&mut self) -> Result<(), Error> {
+        self.reader = BufReader::new(File::open(&self.path)?);
+        self.reader.seek(SeekFrom::Start(self.data_start_pos))?;
+        self.finished = false;
+        self.next_line = None;
+        self.fill_next_line()?;
+        Ok(())
+    }
+}
+
+impl ArffFileStream {
+    pub fn new(path: PathBuf, class_index: usize) -> Result<Self, Error> {
+        let file = File::open(&path)?;
+        let mut reader = BufReader::new(file);
+
+        let (header, data_start_pos) = parse_header(&mut reader, class_index)?;
+
+        let mut stream = ArffFileStream {
+            path,
+            reader,
+            header: Arc::new(header),
+            data_start_pos,
+            next_line: None,
+            finished: false,
+        };
+
+        stream.fill_next_line()?;
+        Ok(stream)
+    }
+
+    fn fill_next_line(&mut self) -> Result<(), Error> {
+        if self.finished {
+            self.next_line = None;
+            return Ok(());
+        }
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let n = self.reader.read_line(&mut line)?;
+            if n == 0 {
+                self.finished = true;
+                self.next_line = None;
+                return Ok(());
+            }
+            if !is_comment_or_empty(&line) {
+                self.next_line = Some(line.trim().to_string());
+                return Ok(());
+            }
+        }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::ErrorKind;
+    use std::io::Write;
+    use tempfile::{NamedTempFile, tempdir};
+
+    fn write_arff(contents: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().expect("tempfile");
+        f.write_all(contents.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn parse_header_and_first_instances() {
+        let arff = r#"%
+@relation weather
+@attribute outlook {sunny, overcast, rainy}
+@attribute temperature numeric
+@attribute humidity numeric
+@attribute windy {TRUE, FALSE}
+@attribute play {yes, no}
+@data
+sunny,85,85,FALSE,no
+sunny,80,90,TRUE,no
+overcast,83,86,FALSE,yes
+rainy,70,96,FALSE,yes
+?,75,?,TRUE,yes
+"#;
+        let tf = write_arff(arff);
+        let mut stream = ArffFileStream::new(tf.path().to_path_buf(), 4).expect("open");
+        let h = stream.header();
+        assert_eq!(h.relation_name(), "weather");
+        assert_eq!(h.number_of_attributes(), 5);
+
+        let inst1 = stream.next_instance().expect("inst1");
+        let v1 = inst1.to_vec();
+        assert_eq!(v1, vec![0.0, 85.0, 85.0, 1.0, 1.0]);
+
+        let _ = stream.next_instance().unwrap();
+        let _ = stream.next_instance().unwrap();
+        let _ = stream.next_instance().unwrap();
+
+        let inst5 = stream.next_instance().unwrap();
+        assert!(inst5.is_missing_at_index(0).unwrap());
+        assert!(inst5.is_missing_at_index(2).unwrap());
+        assert!(!stream.has_more_instances());
+
+        stream.restart().unwrap();
+        let inst1_again = stream.next_instance().unwrap();
+        assert_eq!(inst1_again.to_vec(), v1);
+    }
+
+    #[test]
+    fn new_missing_file_returns_err_not_found() {
+        let err = ArffFileStream::new("no/such/file.arff".into(), 0).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn header_without_data_errors_unexpected_eof() {
+        let tf = write_arff("@relation r\n@attribute a numeric\n");
+        let err = ArffFileStream::new(tf.path().to_path_buf(), 0).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn unsupported_header_directive_errors() {
+        let tf = write_arff("@relation r\n@foo bar\n@data\n1\n");
+        let err = ArffFileStream::new(tf.path().to_path_buf(), 0).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn nominal_domain_without_closing_brace_errors() {
+        let tf = write_arff("@relation r\n@attribute outlook {sunny, rainy\n@data\nsunny\n");
+        let err = ArffFileStream::new(tf.path().to_path_buf(), 0).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn data_row_with_wrong_arity_returns_none() {
+        let tf = write_arff("@relation r\n@attribute a numeric\n@attribute b numeric\n@data\n1\n");
+        let mut stream = ArffFileStream::new(tf.path().to_path_buf(), 1).unwrap();
+        assert!(stream.next_instance().is_none());
+    }
+
+    #[test]
+    fn invalid_numeric_value_returns_none() {
+        let tf = write_arff("@relation r\n@attribute x numeric\n@data\nabc\n");
+        let mut stream = ArffFileStream::new(tf.path().to_path_buf(), 0).unwrap();
+        assert!(stream.next_instance().is_none());
+    }
+
+    #[test]
+    fn fill_next_line_when_finished_is_noop() {
+        let tf = write_arff("@relation r\n@attribute a numeric\n@data\n1\n");
+        let mut s = ArffFileStream::new(tf.path().to_path_buf(), 0).unwrap();
+        s.finished = true;
+        s.next_line = Some("x".into());
+        s.fill_next_line().unwrap();
+        assert!(s.next_line.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn next_instance_sets_finished_on_io_error() {
+        let tf = write_arff("@relation r\n@attribute a numeric\n@data\n1\n2\n");
+        let mut s = ArffFileStream::new(tf.path().to_path_buf(), 0).unwrap();
+        let _ = s.next_instance().unwrap();
+        let dir = tempdir().unwrap();
+        s.reader = std::io::BufReader::new(std::fs::File::open(dir.path()).unwrap());
+        let _ = s.next_instance();
+        assert!(s.finished);
+    }
+
+    #[test]
+    fn parse_header_attribute_before_relation_is_seen() {
+        let tf = write_arff("@attribute a numeric\n@data\n1\n");
+        let s = ArffFileStream::new(tf.path().to_path_buf(), 0).unwrap();
+        assert_eq!(s.header().number_of_attributes(), 1);
+        assert_eq!(s.header().relation_name(), "unnamed_relation");
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn restart_after_file_removed_returns_err() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("data.arff");
+        std::fs::write(&path, "@relation r\n@attribute x numeric\n@data\n1\n").unwrap();
+        let mut stream = ArffFileStream::new(path.clone(), 0).unwrap();
+        fs::remove_file(&path).unwrap();
+        let err = stream.restart().unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::NotFound);
+    }
+}

--- a/src/streams/arff/mod.rs
+++ b/src/streams/arff/mod.rs
@@ -1,0 +1,2 @@
+pub mod arff_file_stream;
+pub(crate) mod parser;

--- a/src/streams/arff/parser.rs
+++ b/src/streams/arff/parser.rs
@@ -1,0 +1,397 @@
+use crate::core::attributes::{AttributeRef, NominalAttribute, NumericAttribute};
+use crate::core::instance_header::InstanceHeader;
+use crate::utils::file_parsing::{split_csv_preserving_quotes, strip_surrounding_quotes};
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Error, ErrorKind, Seek};
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub(super) enum AttributeKind {
+    Numeric,
+    Nominal(Vec<String>),
+}
+
+pub(super) fn is_comment_or_empty(s: &str) -> bool {
+    let t = s.trim();
+    t.is_empty() || t.starts_with('%')
+}
+
+pub(super) fn parse_header(
+    reader: &mut BufReader<File>,
+    class_index: usize,
+) -> Result<(InstanceHeader, u64), Error> {
+    let mut relation: Option<String> = None;
+    let mut attributes: Vec<AttributeRef> = Vec::new();
+    let mut line = String::new();
+    let mut pending_line: Option<String> = None;
+
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line)?;
+        if n == 0 {
+            return Err(Error::new(
+                ErrorKind::UnexpectedEof,
+                "ARFF file ended before @data",
+            ));
+        }
+        if is_comment_or_empty(&line) {
+            continue;
+        }
+
+        let low = line.to_lowercase();
+        if low.starts_with("@relation") {
+            let raw = line.trim()[9..].trim();
+            let rel = strip_surrounding_quotes(raw).to_string();
+            relation = Some(rel);
+            break;
+        } else if low.starts_with("@attribute") || low.starts_with("@data") {
+            pending_line = Some(line.clone());
+            break;
+        }
+    }
+
+    let data_start_pos: u64;
+    loop {
+        if let Some(pending) = pending_line.take() {
+            line = pending;
+        } else {
+            line.clear();
+            let n = reader.read_line(&mut line)?;
+            if n == 0 {
+                return Err(Error::new(
+                    ErrorKind::UnexpectedEof,
+                    "ARFF file ended before @data",
+                ));
+            }
+        }
+
+        if is_comment_or_empty(&line) {
+            continue;
+        }
+
+        let low = line.to_lowercase();
+        if low.starts_with("@attribute") {
+            let (name, kind) = parse_attribute_line(&line)?;
+            match kind {
+                AttributeKind::Numeric => {
+                    let attribute = NumericAttribute::new(name);
+                    attributes.push(Arc::new(attribute) as AttributeRef);
+                }
+                AttributeKind::Nominal(values) => {
+                    let mut map = HashMap::new();
+                    for (i, v) in values.iter().enumerate() {
+                        map.insert(v.clone(), i);
+                    }
+                    let attribute = NominalAttribute::with_values(name, values, map);
+                    attributes.push(Arc::new(attribute) as AttributeRef);
+                }
+            }
+        } else if low.starts_with("@data") {
+            data_start_pos = reader.stream_position()?;
+            break;
+        } else {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("Unsupported header directive: {}", line.trim()),
+            ));
+        }
+    }
+
+    let header = InstanceHeader {
+        attributes,
+        class_index,
+        relation_name: relation.unwrap_or_else(|| "unnamed_relation".to_string()),
+    };
+
+    Ok((header, data_start_pos))
+}
+
+pub(super) fn parse_attribute_line(line: &str) -> Result<(String, AttributeKind), Error> {
+    let rest = {
+        let mut l = line.trim();
+        let low = l.to_ascii_lowercase();
+        if !low.starts_with("@attribute") {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "Line is not '@attribute'",
+            ));
+        }
+        if let Some(idx) = low.find("@attribute") {
+            l = &l[idx + "@attribute".len()..];
+        }
+        l.trim()
+    };
+
+    let (name, after_name) = if rest.starts_with('\'') || rest.starts_with('"') {
+        let quote = rest.chars().next().unwrap();
+        let mut end = None;
+        for (i, c) in rest.char_indices().skip(1) {
+            if c == quote {
+                end = Some(i);
+                break;
+            }
+        }
+        let end = end.ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidData,
+                "Attribute name without closing quote marks",
+            )
+        })?;
+        let name = rest[1..end].to_string();
+        (name, rest[end + 1..].trim())
+    } else {
+        let mut it = rest.splitn(2, char::is_whitespace);
+        let name = it.next().unwrap().to_string();
+        let after = it
+            .next()
+            .ok_or_else(|| Error::new(ErrorKind::InvalidData, "Attribute type is missing"))?;
+        (name, after.trim())
+    };
+
+    let low = after_name.to_ascii_lowercase();
+    if low.starts_with("numeric") || low.starts_with("real") || low.starts_with("integer") {
+        return Ok((name, AttributeKind::Numeric));
+    }
+
+    let after_name = after_name.trim();
+    if after_name.starts_with('{') {
+        let close = after_name
+            .rfind('}')
+            .ok_or_else(|| Error::new(ErrorKind::InvalidData, "Nominal set without closing '}'"))?;
+
+        let inside = &after_name[1..close];
+        let values = inside
+            .split(',')
+            .map(|s| strip_surrounding_quotes(s.trim()).to_string())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>();
+
+        if values.is_empty() {
+            return Err(Error::new(ErrorKind::InvalidData, "Empty nominal domain"));
+        }
+
+        return Ok((name, AttributeKind::Nominal(values)));
+    }
+
+    Err(Error::new(
+        ErrorKind::InvalidData,
+        format!("Attribute kind not supported: {after_name}"),
+    ))
+}
+
+pub(super) fn parse_instance_values(
+    header: &InstanceHeader,
+    line: &str,
+) -> Result<Vec<f64>, Error> {
+    let tokens = split_csv_preserving_quotes(line);
+    if tokens.len() != header.attributes.len() {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            format!(
+                "Number of columns ({}) differs from number of attributes ({})",
+                tokens.len(),
+                header.attributes.len()
+            ),
+        ));
+    }
+
+    let mut values = Vec::with_capacity(tokens.len());
+    for (idx, raw) in tokens.into_iter().enumerate() {
+        let raw = raw.trim();
+        if raw == "?" {
+            values.push(f64::NAN);
+            continue;
+        }
+
+        let attr = &header.attributes[idx];
+
+        if attr.as_any().is::<NumericAttribute>() {
+            let v: f64 = raw.parse().map_err(|_| {
+                Error::new(
+                    ErrorKind::InvalidData,
+                    format!("Invalid numeric value '{raw}' for attribute #{idx}"),
+                )
+            })?;
+            values.push(v);
+            continue;
+        }
+
+        if let Some(nominal) = attr.as_any().downcast_ref::<NominalAttribute>() {
+            let key = strip_surrounding_quotes(raw);
+            let Some(&pos) = nominal.label_to_index.get(key) else {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    format!("Nominal value '{key}' not found in domain of attribute #{idx}"),
+                ));
+            };
+            values.push(pos as f64);
+            continue;
+        }
+
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            format!("Unsupported attribute type at column #{idx}"),
+        ));
+    }
+
+    Ok(values)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::attributes::{Attribute, AttributeRef, NominalAttribute, NumericAttribute};
+    use crate::core::instance_header::InstanceHeader;
+    use std::any::Any;
+    use std::collections::HashMap;
+    use std::fs::File;
+    use std::io::{BufReader, ErrorKind, Write};
+    use std::sync::Arc;
+    use tempfile::NamedTempFile;
+
+    fn hdr(attrs: Vec<AttributeRef>, class_index: usize) -> InstanceHeader {
+        InstanceHeader::new("r".into(), attrs, class_index)
+    }
+
+    fn write_temp(contents: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().expect("tempfile");
+        f.write_all(contents.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn parse_attribute_line_missing_type_after_name() {
+        let err = parse_attribute_line("@attribute outlook").unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn parse_attribute_line_name_without_closing_quote() {
+        let err = parse_attribute_line("@attribute 'bad {x, y}").unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn parse_attribute_line_rejects_non_attribute_line() {
+        let err = parse_attribute_line("@relation r").unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn parse_attribute_line_empty_nominal_domain() {
+        let err = parse_attribute_line("@attribute a {}").unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn parse_attribute_line_whitespace_only_nominal_domain() {
+        let err = parse_attribute_line("@attribute a {   }").unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn parse_attribute_line_trailing_comma_nominal_domain() {
+        let (name, kind) = parse_attribute_line("@attribute a {x, }").unwrap();
+        assert_eq!(name, "a");
+        match kind {
+            AttributeKind::Nominal(v) => assert_eq!(v, vec!["x"]),
+            _ => panic!("expected nominal"),
+        }
+    }
+
+    #[test]
+    fn parse_attribute_line_nominal_missing_closing_brace() {
+        let err = parse_attribute_line("@attribute a {x, y").unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn parse_attribute_line_unsupported_type_string() {
+        let err = parse_attribute_line("@attribute note string").unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn parse_instance_values_wrong_arity() {
+        let h = hdr(
+            vec![
+                Arc::new(NumericAttribute::new("a".into())) as AttributeRef,
+                Arc::new(NumericAttribute::new("b".into())) as AttributeRef,
+            ],
+            0,
+        );
+        let err = parse_instance_values(&h, "1").unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn parse_instance_values_invalid_numeric() {
+        let h = hdr(
+            vec![Arc::new(NumericAttribute::new("x".into())) as AttributeRef],
+            0,
+        );
+        let err = parse_instance_values(&h, "abc").unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn parse_instance_values_unknown_nominal() {
+        let values = vec!["x".into(), "y".into()];
+        let mut map = HashMap::new();
+        map.insert("x".into(), 0);
+        map.insert("y".into(), 1);
+        let nom = NominalAttribute::with_values("a".into(), values, map);
+        let h = hdr(vec![Arc::new(nom) as AttributeRef], 0);
+        let err = parse_instance_values(&h, "z").unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[derive(Debug)]
+    struct DummyAttr;
+    impl Attribute for DummyAttr {
+        fn name(&self) -> String {
+            "d".into()
+        }
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn arff_representation(&self) -> String {
+            "@attribute d dummy".into()
+        }
+    }
+
+    #[test]
+    fn parse_instance_values_unsupported_attribute_type() {
+        let h = hdr(vec![Arc::new(DummyAttr) as AttributeRef], 0);
+        let err = parse_instance_values(&h, "42").unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn parse_header_unexpected_eof_before_data() {
+        let tf = write_temp("@relation r\n@attribute a numeric\n");
+        let mut br = BufReader::new(File::open(tf.path()).unwrap());
+        let err = parse_header(&mut br, 0).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn parse_header_unsupported_header_directive() {
+        let tf = write_temp("@relation r\n@foo bar\n@data\n1\n");
+        let mut br = BufReader::new(File::open(tf.path()).unwrap());
+        let err = parse_header(&mut br, 0).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn parse_header_attribute_before_relation_is_reprocessed() {
+        let tf = write_temp("@attribute a numeric\n@data\n1\n");
+        let mut br = BufReader::new(File::open(tf.path()).unwrap());
+        let (h, _pos) = parse_header(&mut br, 0).unwrap();
+        assert_eq!(h.relation_name(), "unnamed_relation");
+        assert_eq!(h.number_of_attributes(), 1);
+    }
+}

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -1,0 +1,2 @@
+pub mod arff;
+pub mod stream;

--- a/src/streams/stream.rs
+++ b/src/streams/stream.rs
@@ -1,5 +1,5 @@
-use crate::instance::Instance;
-use crate::instance_header::InstanceHeader;
+use crate::core::instance_header::InstanceHeader;
+use crate::core::instances::instance::Instance;
 use std::io::Error;
 
 pub trait Stream {

--- a/src/utils/file_parsing.rs
+++ b/src/utils/file_parsing.rs
@@ -1,0 +1,65 @@
+#[inline]
+pub fn strip_surrounding_quotes(s: &str) -> &str {
+    let b = s.as_bytes();
+    if b.len() >= 2 {
+        let first = b[0];
+        let last = b[b.len() - 1];
+        if (first == b'\'' && last == b'\'') || (first == b'"' && last == b'"') {
+            return &s[1..s.len() - 1];
+        }
+    }
+    s
+}
+
+pub fn split_csv_preserving_quotes(line: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    let mut in_quotes: Option<char> = None;
+
+    for ch in line.chars() {
+        match in_quotes {
+            Some(q) => {
+                if ch == q {
+                    in_quotes = None;
+                    cur.push(ch);
+                } else {
+                    cur.push(ch);
+                }
+            }
+            None => {
+                if ch == '"' || ch == '\'' {
+                    in_quotes = Some(ch);
+                    cur.push(ch);
+                } else if ch == ',' {
+                    out.push(cur.trim().to_string());
+                    cur.clear();
+                } else {
+                    cur.push(ch);
+                }
+            }
+        }
+    }
+    if !cur.is_empty() {
+        out.push(cur.trim().to_string());
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_quotes_works() {
+        assert_eq!(strip_surrounding_quotes("'a,b'"), "a,b");
+        assert_eq!(strip_surrounding_quotes(r#""x""#), "x");
+        assert_eq!(strip_surrounding_quotes("nq"), "nq");
+    }
+
+    #[test]
+    fn split_preserving_quotes() {
+        let line = r#"'sunny',85,"85",FALSE,no"#;
+        let p = split_csv_preserving_quotes(line);
+        assert_eq!(p, vec!["'sunny'", "85", "\"85\"", "FALSE", "no"]);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod file_parsing;


### PR DESCRIPTION
This commit closes #4 by adding the first concrete stream of the project, which reads files in `.arff` file format and creates an instance header and instances.

Along with the mentioned feature, the project has also been reorganized, as more files were added and therefore the need for structure emerged.

To help with our goal of reaching at least 90% code coverage, all new methods added are also unit-tested.