### PR TITLE
Feat: implementation of InstanceConditionalTest

### DIFF
--- a/src/classifiers/hoeffding_tree/instance_conditional_test/instance_conditional_test.rs
+++ b/src/classifiers/hoeffding_tree/instance_conditional_test/instance_conditional_test.rs
@@ -1,0 +1,9 @@
+use crate::core::instances::Instance;
+use std::sync::Arc;
+
+pub trait InstanceConditionalTest {
+    fn branch_for_instance(&self, instance: Arc<dyn Instance>) -> Option<usize>;
+    fn result_known_for_instance(&self, instance: Arc<dyn Instance>) -> bool;
+    fn max_branches(&self) -> usize;
+    fn get_atts_test_depends_on(&self) -> Vec<usize>;
+}

--- a/src/classifiers/hoeffding_tree/instance_conditional_test/mod.rs
+++ b/src/classifiers/hoeffding_tree/instance_conditional_test/mod.rs
@@ -1,0 +1,4 @@
+mod instance_conditional_test;
+mod nominal_attribute_binary_test;
+mod nominal_attribute_multiway_test;
+mod numeric_attribute_binary_test;

--- a/src/classifiers/hoeffding_tree/instance_conditional_test/nominal_attribute_binary_test.rs
+++ b/src/classifiers/hoeffding_tree/instance_conditional_test/nominal_attribute_binary_test.rs
@@ -1,0 +1,47 @@
+use crate::classifiers::hoeffding_tree::instance_conditional_test::instance_conditional_test::InstanceConditionalTest;
+use crate::core::instances::Instance;
+use std::sync::Arc;
+
+struct NominalAttributeBinaryTest {
+    attribute_index: usize,
+    attribute_value: usize,
+}
+
+impl NominalAttributeBinaryTest {
+    pub fn new(attribute_index: usize, attribute_value: usize) -> Self {
+        Self {
+            attribute_index,
+            attribute_value,
+        }
+    }
+}
+
+impl InstanceConditionalTest for NominalAttributeBinaryTest {
+    fn branch_for_instance(&self, instance: Arc<dyn Instance>) -> Option<usize> {
+        let index = if self.attribute_index < instance.class_index() {
+            self.attribute_index
+        } else {
+            self.attribute_index + 1
+        };
+
+        if instance.is_missing_at_index(index).ok()? {
+            return None;
+        }
+
+        let value = instance.value_at_index(index)?;
+
+        Some((value as usize != self.attribute_value) as usize)
+    }
+
+    fn result_known_for_instance(&self, instance: Arc<dyn Instance>) -> bool {
+        self.branch_for_instance(instance).is_some_and(|b| b == 0)
+    }
+
+    fn max_branches(&self) -> usize {
+        2
+    }
+
+    fn get_atts_test_depends_on(&self) -> Vec<usize> {
+        vec![self.attribute_index]
+    }
+}

--- a/src/classifiers/hoeffding_tree/instance_conditional_test/nominal_attribute_multiway_test.rs
+++ b/src/classifiers/hoeffding_tree/instance_conditional_test/nominal_attribute_multiway_test.rs
@@ -1,0 +1,38 @@
+use crate::classifiers::hoeffding_tree::instance_conditional_test::instance_conditional_test::InstanceConditionalTest;
+use crate::core::instances::Instance;
+use std::sync::Arc;
+
+pub struct NominalAttributeMultiwayTest {
+    attribute_index: usize,
+}
+
+impl NominalAttributeMultiwayTest {
+    pub fn new(attribute_index: usize) -> Self {
+        Self { attribute_index }
+    }
+}
+
+impl InstanceConditionalTest for NominalAttributeMultiwayTest {
+    fn branch_for_instance(&self, instance: Arc<dyn Instance>) -> Option<usize> {
+        if instance
+            .is_missing_at_index(self.attribute_index)
+            .unwrap_or(true)
+        {
+            return None;
+        }
+
+        Some(instance.value_at_index(self.attribute_index)? as usize)
+    }
+
+    fn result_known_for_instance(&self, instance: Arc<dyn Instance>) -> bool {
+        self.branch_for_instance(instance).is_some_and(|b| b == 0)
+    }
+
+    fn max_branches(&self) -> usize {
+        usize::MAX
+    }
+
+    fn get_atts_test_depends_on(&self) -> Vec<usize> {
+        vec![self.attribute_index]
+    }
+}

--- a/src/classifiers/hoeffding_tree/instance_conditional_test/numeric_attribute_binary_test.rs
+++ b/src/classifiers/hoeffding_tree/instance_conditional_test/numeric_attribute_binary_test.rs
@@ -1,0 +1,45 @@
+use crate::classifiers::hoeffding_tree::instance_conditional_test::instance_conditional_test::InstanceConditionalTest;
+use crate::core::instances::Instance;
+use std::sync::Arc;
+
+struct NumericAttributeBinaryTest {
+    attribute_index: usize,
+    attribute_value: usize,
+    equals_passes_test: bool,
+}
+
+impl NumericAttributeBinaryTest {
+    pub fn new(attribute_index: usize, attribute_value: usize, equals_passes_test: bool) -> Self {
+        Self {
+            attribute_index,
+            attribute_value,
+            equals_passes_test,
+        }
+    }
+}
+
+impl InstanceConditionalTest for NumericAttributeBinaryTest {
+    fn branch_for_instance(&self, instance: Arc<dyn Instance>) -> Option<usize> {
+        let value = instance.value_at_index(self.attribute_index)?;
+
+        if value == self.attribute_value as f64 {
+            return Some(if self.equals_passes_test { 0 } else { 1 });
+        }
+        if value < self.attribute_value as f64 {
+            return Some(0);
+        }
+        Some(1)
+    }
+
+    fn result_known_for_instance(&self, instance: Arc<dyn Instance>) -> bool {
+        self.branch_for_instance(instance).is_some_and(|b| b == 0)
+    }
+
+    fn max_branches(&self) -> usize {
+        2
+    }
+
+    fn get_atts_test_depends_on(&self) -> Vec<usize> {
+        vec![self.attribute_index]
+    }
+}

--- a/src/classifiers/hoeffding_tree/mod.rs
+++ b/src/classifiers/hoeffding_tree/mod.rs
@@ -1,0 +1,1 @@
+mod instance_conditional_test;

--- a/src/classifiers/mod.rs
+++ b/src/classifiers/mod.rs
@@ -1,2 +1,3 @@
 mod attribute_class_observers;
 mod classifier;
+mod hoeffding_tree;


### PR DESCRIPTION
This commit closes #26 by implementing the InstanceConditionalTest trait and it's concrete implementations for nominal binary, nominal multiway and numeric binary.

This commit is the first step to the implementation of the Nodes struct, necessary for Hoeffding Tree construction.