### PR TITLE
feat: Implemeted nodes for Hoeffding Tree

### DIFF
--- a/src/classifiers/classifier.rs
+++ b/src/classifiers/classifier.rs
@@ -3,7 +3,7 @@ use crate::core::instances::Instance;
 use std::sync::Arc;
 
 pub trait Classifier {
-    fn get_votes_for_instance(&self, instance: &dyn Instance) -> Option<Vec<f64>>;
+    fn get_votes_for_instance(&self, instance: &dyn Instance) -> Vec<f64>;
     fn set_model_context(&mut self, header: Arc<InstanceHeader>);
     fn train_on_instance(&mut self, instance: Box<dyn Instance>);
 }

--- a/src/classifiers/hoeffding_tree/hoeffding_tree.rs
+++ b/src/classifiers/hoeffding_tree/hoeffding_tree.rs
@@ -1,0 +1,44 @@
+use crate::classifiers::attribute_class_observers::{
+    AttributeClassObserver, GaussianNumericAttributeClassObserver, NominalAttributeClassObserver,
+};
+use crate::core::instances::Instance;
+use std::sync::Arc;
+
+pub struct HoeffdingTree {
+    nb_threshold_option: Option<f64>,
+}
+
+impl HoeffdingTree {
+    pub fn new() -> Self {
+        Self {
+            nb_threshold_option: None,
+        }
+    }
+
+    pub fn set_nb_threshold(&mut self, threshold: f64) {
+        self.nb_threshold_option = Some(threshold);
+    }
+
+    pub fn get_nb_threshold(&self) -> Option<f64> {
+        self.nb_threshold_option
+    }
+
+    pub fn model_attribute_index_to_instance_attribute_index(
+        index: usize,
+        instance: &Arc<dyn Instance>,
+    ) -> usize {
+        let class_index = instance.class_index();
+        if class_index > index {
+            return index;
+        }
+        index + 1
+    }
+
+    pub fn new_nominal_class_observer(&self) -> Box<dyn AttributeClassObserver> {
+        Box::new(NominalAttributeClassObserver::new())
+    }
+
+    pub fn new_numeric_class_observer(&self) -> Box<dyn AttributeClassObserver> {
+        Box::new(GaussianNumericAttributeClassObserver::new())
+    }
+}

--- a/src/classifiers/hoeffding_tree/instance_conditional_test/mod.rs
+++ b/src/classifiers/hoeffding_tree/instance_conditional_test/mod.rs
@@ -1,3 +1,7 @@
+pub use instance_conditional_test::InstanceConditionalTest;
+pub use nominal_attribute_binary_test::NominalAttributeBinaryTest;
+pub use nominal_attribute_multiway_test::NominalAttributeMultiwayTest;
+pub use numeric_attribute_binary_test::NumericAttributeBinaryTest;
 mod instance_conditional_test;
 mod nominal_attribute_binary_test;
 mod nominal_attribute_multiway_test;

--- a/src/classifiers/hoeffding_tree/instance_conditional_test/nominal_attribute_binary_test.rs
+++ b/src/classifiers/hoeffding_tree/instance_conditional_test/nominal_attribute_binary_test.rs
@@ -2,7 +2,7 @@ use crate::classifiers::hoeffding_tree::instance_conditional_test::instance_cond
 use crate::core::instances::Instance;
 use std::sync::Arc;
 
-struct NominalAttributeBinaryTest {
+pub struct NominalAttributeBinaryTest {
     attribute_index: usize,
     attribute_value: usize,
 }

--- a/src/classifiers/hoeffding_tree/instance_conditional_test/numeric_attribute_binary_test.rs
+++ b/src/classifiers/hoeffding_tree/instance_conditional_test/numeric_attribute_binary_test.rs
@@ -2,7 +2,7 @@ use crate::classifiers::hoeffding_tree::instance_conditional_test::instance_cond
 use crate::core::instances::Instance;
 use std::sync::Arc;
 
-struct NumericAttributeBinaryTest {
+pub struct NumericAttributeBinaryTest {
     attribute_index: usize,
     attribute_value: usize,
     equals_passes_test: bool,

--- a/src/classifiers/hoeffding_tree/mod.rs
+++ b/src/classifiers/hoeffding_tree/mod.rs
@@ -1,1 +1,3 @@
+mod hoeffding_tree;
 mod instance_conditional_test;
+mod nodes;

--- a/src/classifiers/hoeffding_tree/nodes/found_node.rs
+++ b/src/classifiers/hoeffding_tree/nodes/found_node.rs
@@ -1,0 +1,35 @@
+use crate::classifiers::hoeffding_tree::nodes::node::Node;
+use crate::classifiers::hoeffding_tree::nodes::split_node::SplitNode;
+use std::sync::Arc;
+
+pub struct FoundNode<'a> {
+    node: Option<&'a dyn Node>,
+    parent: Option<&'a SplitNode>,
+    parent_branch: usize,
+}
+
+impl<'a> FoundNode<'a> {
+    pub fn new(
+        node: Option<&'a dyn Node>,
+        parent: Option<&'a SplitNode>,
+        parent_branch: usize,
+    ) -> Self {
+        Self {
+            node,
+            parent,
+            parent_branch,
+        }
+    }
+
+    pub fn get_node(&self) -> &Option<&'a dyn Node> {
+        &self.node
+    }
+
+    pub fn get_parent(&self) -> &Option<&'a SplitNode> {
+        &self.parent
+    }
+
+    pub fn get_parent_branch(&self) -> usize {
+        self.parent_branch
+    }
+}

--- a/src/classifiers/hoeffding_tree/nodes/learning_nodes/active_learning_node.rs
+++ b/src/classifiers/hoeffding_tree/nodes/learning_nodes/active_learning_node.rs
@@ -1,0 +1,110 @@
+use crate::classifiers::attribute_class_observers::AttributeClassObserver;
+use crate::classifiers::hoeffding_tree::hoeffding_tree::HoeffdingTree;
+use crate::classifiers::hoeffding_tree::nodes::LearningNode;
+use crate::classifiers::hoeffding_tree::nodes::SplitNode;
+use crate::classifiers::hoeffding_tree::nodes::found_node::FoundNode;
+use crate::classifiers::hoeffding_tree::nodes::node::Node;
+use crate::core::attributes::NominalAttribute;
+use crate::core::instances::Instance;
+use std::sync::Arc;
+
+pub struct ActiveLearningNode {
+    observed_class_distribution: Vec<f64>,
+    weight_seen_at_last_split_evaluation: f64,
+    attribute_observers: Vec<Option<Box<dyn AttributeClassObserver>>>,
+    is_initialized: bool,
+}
+
+impl ActiveLearningNode {
+    pub fn new(self, observed_class_distribution: Vec<f64>) -> Self {
+        Self {
+            observed_class_distribution,
+            weight_seen_at_last_split_evaluation: self.get_weight_seen(),
+            attribute_observers: Vec::new(),
+            is_initialized: false,
+        }
+    }
+
+    pub fn get_weight_seen(&self) -> f64 {
+        self.observed_class_distribution.iter().sum()
+    }
+
+    pub fn get_weight_seen_at_last_split_evaluation(&self) -> f64 {
+        self.weight_seen_at_last_split_evaluation
+    }
+
+    pub fn set_weight_seen_at_last_split_evaluation(&mut self, weight: f64) {
+        self.weight_seen_at_last_split_evaluation = weight;
+    }
+}
+
+impl Node for ActiveLearningNode {
+    fn get_observed_class_distribution(&self) -> &Vec<f64> {
+        &self.observed_class_distribution
+    }
+
+    fn is_leaf(&self) -> bool {
+        true
+    }
+
+    fn filter_instance_to_leaf<'a>(
+        &'a self,
+        instance: Arc<dyn Instance>,
+        parent: Option<&'a SplitNode>,
+        parent_branch: usize,
+    ) -> FoundNode<'a> {
+        FoundNode::new(Some(self), parent, parent_branch)
+    }
+
+    fn get_observed_class_distribution_at_leaves_reachable_through_this_node(&self) -> Vec<f64> {
+        self.observed_class_distribution.clone()
+    }
+
+    fn get_class_votes(&self, instance: &dyn Instance, hoeffding_tree: &HoeffdingTree) -> Vec<f64> {
+        self.observed_class_distribution.clone()
+    }
+}
+
+impl LearningNode for ActiveLearningNode {
+    fn learn_from_instance(&mut self, instance: Arc<dyn Instance>, hoeffding_tree: &HoeffdingTree) {
+        if !self.is_initialized {
+            self.attribute_observers = (0..instance.number_of_attributes()).map(|_| None).collect();
+            self.is_initialized = true;
+        }
+
+        if let Some(class_index) = instance.class_value() {
+            let weight = instance.weight();
+            self.observed_class_distribution[class_index as usize] += weight
+        }
+
+        for i in 0..instance.number_of_attributes() - 1 {
+            let instance_attribute_index =
+                HoeffdingTree::model_attribute_index_to_instance_attribute_index(i, &instance);
+
+            if self.attribute_observers[i].is_none() {
+                if let Some(attribute) = instance.attribute_at_index(instance_attribute_index) {
+                    let observer: Box<dyn AttributeClassObserver> =
+                        if attribute.as_any().is::<NominalAttribute>() {
+                            hoeffding_tree.new_nominal_class_observer()
+                        } else {
+                            hoeffding_tree.new_numeric_class_observer()
+                        };
+                    self.attribute_observers[i] = Some(observer);
+                }
+            }
+
+            if let Some(observer) = self.attribute_observers[i].as_mut() {
+                if let (Some(class_index), Some(value)) = (
+                    instance.class_value(),
+                    instance.value_at_index(instance_attribute_index),
+                ) {
+                    observer.observe_attribute_class(
+                        value,
+                        class_index as usize,
+                        instance.weight(),
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/classifiers/hoeffding_tree/nodes/learning_nodes/inactive_learning_node.rs
+++ b/src/classifiers/hoeffding_tree/nodes/learning_nodes/inactive_learning_node.rs
@@ -1,0 +1,55 @@
+use crate::classifiers::hoeffding_tree::hoeffding_tree::HoeffdingTree;
+use crate::classifiers::hoeffding_tree::nodes::FoundNode;
+use crate::classifiers::hoeffding_tree::nodes::LearningNode;
+use crate::classifiers::hoeffding_tree::nodes::Node;
+use crate::classifiers::hoeffding_tree::nodes::SplitNode;
+use crate::core::instances::Instance;
+use std::sync::Arc;
+
+pub struct InactiveLearningNode {
+    observed_class_distribution: Vec<f64>,
+}
+
+impl InactiveLearningNode {
+    pub fn new(observed_class_distribution: Vec<f64>) -> Self {
+        Self {
+            observed_class_distribution,
+        }
+    }
+}
+
+impl Node for InactiveLearningNode {
+    fn get_observed_class_distribution(&self) -> &Vec<f64> {
+        &self.observed_class_distribution
+    }
+
+    fn is_leaf(&self) -> bool {
+        true
+    }
+
+    fn filter_instance_to_leaf<'a>(
+        &'a self,
+        instance: Arc<dyn Instance>,
+        parent: Option<&'a SplitNode>,
+        parent_branch: usize,
+    ) -> FoundNode<'a> {
+        FoundNode::new(Some(self), parent, parent_branch)
+    }
+
+    fn get_observed_class_distribution_at_leaves_reachable_through_this_node(&self) -> Vec<f64> {
+        self.observed_class_distribution.clone()
+    }
+
+    fn get_class_votes(&self, instance: &dyn Instance, hoeffding_tree: &HoeffdingTree) -> Vec<f64> {
+        self.observed_class_distribution.clone()
+    }
+}
+
+impl LearningNode for InactiveLearningNode {
+    fn learn_from_instance(&mut self, instance: Arc<dyn Instance>, hoeffding_tree: &HoeffdingTree) {
+        if let Some(value) = instance.class_value() {
+            let weight = instance.weight();
+            self.observed_class_distribution[value as usize] += weight;
+        }
+    }
+}

--- a/src/classifiers/hoeffding_tree/nodes/learning_nodes/learning_nb/learning_node_nb.rs
+++ b/src/classifiers/hoeffding_tree/nodes/learning_nodes/learning_nb/learning_node_nb.rs
@@ -1,0 +1,121 @@
+use crate::classifiers::attribute_class_observers::AttributeClassObserver;
+use crate::classifiers::bayes::naive_bayes::NaiveBayes;
+use crate::classifiers::hoeffding_tree::hoeffding_tree::HoeffdingTree;
+use crate::classifiers::hoeffding_tree::nodes::FoundNode;
+use crate::classifiers::hoeffding_tree::nodes::LearningNode;
+use crate::classifiers::hoeffding_tree::nodes::Node;
+use crate::classifiers::hoeffding_tree::nodes::SplitNode;
+use crate::core::attributes::NominalAttribute;
+use crate::core::instances::Instance;
+use std::sync::Arc;
+
+pub struct LearningNodeNB {
+    observed_class_distribution: Vec<f64>,
+    weight_seen_at_last_split_evaluation: f64,
+    attribute_observers: Vec<Option<Box<dyn AttributeClassObserver>>>,
+    is_initialized: bool,
+}
+
+impl LearningNodeNB {
+    pub fn new(observed_class_distribution: Vec<f64>) -> Self {
+        let weight_seen = observed_class_distribution.iter().sum();
+        Self {
+            observed_class_distribution,
+            weight_seen_at_last_split_evaluation: weight_seen,
+            attribute_observers: Vec::new(),
+            is_initialized: false,
+        }
+    }
+
+    pub fn get_weight_seen(&self) -> f64 {
+        self.observed_class_distribution.iter().sum()
+    }
+
+    pub fn get_weight_seen_at_last_split_evaluation(&self) -> f64 {
+        self.weight_seen_at_last_split_evaluation
+    }
+
+    pub fn set_weight_seen_at_last_split_evaluation(&mut self, weight: f64) {
+        self.weight_seen_at_last_split_evaluation = weight;
+    }
+}
+
+impl Node for LearningNodeNB {
+    fn get_observed_class_distribution(&self) -> &Vec<f64> {
+        &self.observed_class_distribution
+    }
+
+    fn is_leaf(&self) -> bool {
+        true
+    }
+
+    fn filter_instance_to_leaf<'a>(
+        &'a self,
+        instance: Arc<dyn Instance>,
+        parent: Option<&'a SplitNode>,
+        parent_branch: usize,
+    ) -> FoundNode<'a> {
+        FoundNode::new(Some(self), parent, parent_branch)
+    }
+
+    fn get_observed_class_distribution_at_leaves_reachable_through_this_node(&self) -> Vec<f64> {
+        self.observed_class_distribution.clone()
+    }
+
+    fn get_class_votes(&self, instance: &dyn Instance, hoeffding_tree: &HoeffdingTree) -> Vec<f64> {
+        if let Some(threshold) = hoeffding_tree.get_nb_threshold() {
+            if (self.get_weight_seen() >= threshold) {
+                return NaiveBayes::do_naive_bayes_prediction(
+                    instance,
+                    &self.observed_class_distribution,
+                    &self.attribute_observers,
+                );
+            }
+        }
+        self.observed_class_distribution.clone()
+    }
+}
+
+impl LearningNode for LearningNodeNB {
+    fn learn_from_instance(&mut self, instance: Arc<dyn Instance>, hoeffding_tree: &HoeffdingTree) {
+        if !self.is_initialized {
+            self.attribute_observers = (0..instance.number_of_attributes()).map(|_| None).collect();
+            self.is_initialized = true;
+        }
+
+        if let Some(class_index) = instance.class_value() {
+            let weight = instance.weight();
+            self.observed_class_distribution[class_index as usize] += weight
+        }
+
+        for i in 0..instance.number_of_attributes() - 1 {
+            let instance_attribute_index =
+                HoeffdingTree::model_attribute_index_to_instance_attribute_index(i, &instance);
+
+            if self.attribute_observers[i].is_none() {
+                if let Some(attribute) = instance.attribute_at_index(instance_attribute_index) {
+                    let observer: Box<dyn AttributeClassObserver> =
+                        if attribute.as_any().is::<NominalAttribute>() {
+                            hoeffding_tree.new_nominal_class_observer()
+                        } else {
+                            hoeffding_tree.new_numeric_class_observer()
+                        };
+                    self.attribute_observers[i] = Some(observer);
+                }
+            }
+
+            if let Some(observer) = self.attribute_observers[i].as_mut() {
+                if let (Some(class_index), Some(value)) = (
+                    instance.class_value(),
+                    instance.value_at_index(instance_attribute_index),
+                ) {
+                    observer.observe_attribute_class(
+                        value,
+                        class_index as usize,
+                        instance.weight(),
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/classifiers/hoeffding_tree/nodes/learning_nodes/learning_nb/learning_node_nb_adaptive.rs
+++ b/src/classifiers/hoeffding_tree/nodes/learning_nodes/learning_nb/learning_node_nb_adaptive.rs
@@ -1,0 +1,160 @@
+use crate::classifiers::attribute_class_observers::AttributeClassObserver;
+use crate::classifiers::bayes::naive_bayes::NaiveBayes;
+use crate::classifiers::hoeffding_tree::hoeffding_tree::HoeffdingTree;
+use crate::classifiers::hoeffding_tree::nodes::LearningNode;
+use crate::classifiers::hoeffding_tree::nodes::Node;
+use crate::classifiers::hoeffding_tree::nodes::SplitNode;
+use crate::classifiers::hoeffding_tree::nodes::found_node::FoundNode;
+use crate::core::attributes::NominalAttribute;
+use crate::core::instances::Instance;
+use std::sync::Arc;
+
+pub struct LearningNodeNBAdaptive {
+    observed_class_distribution: Vec<f64>,
+    weight_seen_at_last_split_evaluation: f64,
+    attribute_observers: Vec<Option<Box<dyn AttributeClassObserver>>>,
+    is_initialized: bool,
+    mc_correct_weight: f64,
+    nb_correct_weight: f64,
+}
+
+impl LearningNodeNBAdaptive {
+    pub fn new(observed_class_distribution: Vec<f64>) -> Self {
+        let weight_seen = observed_class_distribution.iter().sum();
+        Self {
+            observed_class_distribution,
+            weight_seen_at_last_split_evaluation: weight_seen,
+            attribute_observers: Vec::new(),
+            is_initialized: false,
+            mc_correct_weight: 0.0,
+            nb_correct_weight: 0.0,
+        }
+    }
+
+    pub fn get_weight_seen(&self) -> f64 {
+        self.observed_class_distribution.iter().sum()
+    }
+
+    pub fn get_weight_seen_at_last_split_evaluation(&self) -> f64 {
+        self.weight_seen_at_last_split_evaluation
+    }
+
+    pub fn set_weight_seen_at_last_split_evaluation(&mut self, weight: f64) {
+        self.weight_seen_at_last_split_evaluation = weight;
+    }
+
+    fn max_index(dist: &[f64]) -> Option<usize> {
+        dist.iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+            .map(|(i, _)| i)
+    }
+
+    fn super_learn_from_instance(
+        &mut self,
+        instance: Arc<dyn Instance>,
+        hoeffding_tree: &HoeffdingTree,
+    ) {
+        if !self.is_initialized {
+            self.attribute_observers = (0..instance.number_of_attributes()).map(|_| None).collect();
+            self.is_initialized = true;
+        }
+
+        if let Some(class_index) = instance.class_value() {
+            let weight = instance.weight();
+            self.observed_class_distribution[class_index as usize] += weight
+        }
+
+        for i in 0..instance.number_of_attributes() - 1 {
+            let instance_attribute_index =
+                HoeffdingTree::model_attribute_index_to_instance_attribute_index(i, &instance);
+
+            if self.attribute_observers[i].is_none() {
+                if let Some(attribute) = instance.attribute_at_index(instance_attribute_index) {
+                    let observer: Box<dyn AttributeClassObserver> =
+                        if attribute.as_any().is::<NominalAttribute>() {
+                            hoeffding_tree.new_nominal_class_observer()
+                        } else {
+                            hoeffding_tree.new_numeric_class_observer()
+                        };
+                    self.attribute_observers[i] = Some(observer);
+                }
+            }
+
+            if let Some(observer) = self.attribute_observers[i].as_mut() {
+                if let (Some(class_index), Some(value)) = (
+                    instance.class_value(),
+                    instance.value_at_index(instance_attribute_index),
+                ) {
+                    observer.observe_attribute_class(
+                        value,
+                        class_index as usize,
+                        instance.weight(),
+                    );
+                }
+            }
+        }
+    }
+}
+
+impl Node for LearningNodeNBAdaptive {
+    fn get_observed_class_distribution(&self) -> &Vec<f64> {
+        &self.observed_class_distribution
+    }
+
+    fn is_leaf(&self) -> bool {
+        true
+    }
+
+    fn filter_instance_to_leaf<'a>(
+        &'a self,
+        instance: Arc<dyn Instance>,
+        parent: Option<&'a SplitNode>,
+        parent_branch: usize,
+    ) -> FoundNode<'a> {
+        FoundNode::new(Some(self), parent, parent_branch)
+    }
+
+    fn get_observed_class_distribution_at_leaves_reachable_through_this_node(&self) -> Vec<f64> {
+        self.observed_class_distribution.clone()
+    }
+
+    fn get_class_votes(&self, instance: &dyn Instance, hoeffding_tree: &HoeffdingTree) -> Vec<f64> {
+        if self.mc_correct_weight > self.nb_correct_weight {
+            return self.observed_class_distribution.clone();
+        }
+        NaiveBayes::do_naive_bayes_prediction(
+            instance,
+            &self.observed_class_distribution,
+            &self.attribute_observers,
+        )
+    }
+}
+
+impl LearningNode for LearningNodeNBAdaptive {
+    fn learn_from_instance(&mut self, instance: Arc<dyn Instance>, hoeffding_tree: &HoeffdingTree) {
+        if let Some(true_class) = instance.class_value() {
+            let weight = instance.weight();
+
+            if let Some(predicted_mc) = Self::max_index(&self.observed_class_distribution) {
+                if predicted_mc == true_class as usize {
+                    self.mc_correct_weight += weight;
+                }
+            }
+
+            let nb_prediction = NaiveBayes::do_naive_bayes_prediction(
+                instance.as_ref(),
+                &self.observed_class_distribution,
+                &self.attribute_observers,
+            );
+
+            if let Some(predicted_nb) = Self::max_index(&nb_prediction) {
+                if predicted_nb == true_class as usize {
+                    self.nb_correct_weight += weight;
+                }
+            }
+        }
+
+        self.super_learn_from_instance(instance, hoeffding_tree)
+    }
+}

--- a/src/classifiers/hoeffding_tree/nodes/learning_nodes/learning_nb/mod.rs
+++ b/src/classifiers/hoeffding_tree/nodes/learning_nodes/learning_nb/mod.rs
@@ -1,0 +1,4 @@
+pub use learning_node_nb::LearningNodeNB;
+pub use learning_node_nb_adaptive::LearningNodeNBAdaptive;
+mod learning_node_nb;
+mod learning_node_nb_adaptive;

--- a/src/classifiers/hoeffding_tree/nodes/learning_nodes/learning_node.rs
+++ b/src/classifiers/hoeffding_tree/nodes/learning_nodes/learning_node.rs
@@ -1,0 +1,7 @@
+use crate::classifiers::hoeffding_tree::hoeffding_tree::HoeffdingTree;
+use crate::core::instances::Instance;
+use std::sync::Arc;
+
+pub trait LearningNode {
+    fn learn_from_instance(&mut self, instance: Arc<dyn Instance>, hoeffding_tree: &HoeffdingTree);
+}

--- a/src/classifiers/hoeffding_tree/nodes/learning_nodes/mod.rs
+++ b/src/classifiers/hoeffding_tree/nodes/learning_nodes/mod.rs
@@ -1,0 +1,9 @@
+pub use active_learning_node::ActiveLearningNode;
+pub use inactive_learning_node::InactiveLearningNode;
+pub use learning_nb::LearningNodeNB;
+pub use learning_nb::*;
+pub use learning_node::LearningNode;
+mod active_learning_node;
+mod inactive_learning_node;
+mod learning_nb;
+mod learning_node;

--- a/src/classifiers/hoeffding_tree/nodes/mod.rs
+++ b/src/classifiers/hoeffding_tree/nodes/mod.rs
@@ -1,0 +1,8 @@
+pub use found_node::FoundNode;
+pub use learning_nodes::*;
+pub use node::Node;
+pub use split_node::SplitNode;
+mod found_node;
+mod learning_nodes;
+mod node;
+mod split_node;

--- a/src/classifiers/hoeffding_tree/nodes/node.rs
+++ b/src/classifiers/hoeffding_tree/nodes/node.rs
@@ -1,0 +1,18 @@
+use crate::classifiers::hoeffding_tree::hoeffding_tree::HoeffdingTree;
+use crate::classifiers::hoeffding_tree::nodes::found_node::FoundNode;
+use crate::classifiers::hoeffding_tree::nodes::split_node::SplitNode;
+use crate::core::instances::Instance;
+use std::sync::Arc;
+
+pub trait Node {
+    fn get_observed_class_distribution(&self) -> &Vec<f64>;
+    fn is_leaf(&self) -> bool;
+    fn filter_instance_to_leaf<'a>(
+        &'a self,
+        instance: Arc<dyn Instance>,
+        parent: Option<&'a SplitNode>,
+        parent_branch: usize,
+    ) -> FoundNode<'a>;
+    fn get_observed_class_distribution_at_leaves_reachable_through_this_node(&self) -> Vec<f64>;
+    fn get_class_votes(&self, instance: &dyn Instance, hoeffding_tree: &HoeffdingTree) -> Vec<f64>;
+}

--- a/src/classifiers/hoeffding_tree/nodes/split_node.rs
+++ b/src/classifiers/hoeffding_tree/nodes/split_node.rs
@@ -1,0 +1,215 @@
+use crate::classifiers::hoeffding_tree::hoeffding_tree::HoeffdingTree;
+use crate::classifiers::hoeffding_tree::instance_conditional_test::InstanceConditionalTest;
+use crate::classifiers::hoeffding_tree::nodes::found_node::FoundNode;
+use crate::classifiers::hoeffding_tree::nodes::node::Node;
+use crate::core::instances::Instance;
+use std::sync::Arc;
+
+pub struct SplitNode {
+    observed_class_distribution: Vec<f64>,
+    split_test: Box<dyn InstanceConditionalTest>,
+    children: Vec<Option<Arc<dyn Node>>>,
+}
+
+impl SplitNode {
+    pub fn new(
+        split_test: Box<dyn InstanceConditionalTest>,
+        observed_class_distribution: Vec<f64>,
+        initial_children_len: Option<usize>,
+    ) -> Self {
+        let children = match initial_children_len {
+            Some(len) => (0..len).map(|_| None).collect(),
+            None => Vec::new(),
+        };
+        Self {
+            observed_class_distribution,
+            split_test,
+            children,
+        }
+    }
+
+    pub fn set_child(&mut self, index: usize, child: Arc<dyn Node>) {
+        if index >= self.children.len() {
+            self.children.resize_with(index + 1, || None);
+        }
+        self.children[index] = Some(child);
+    }
+
+    pub fn get_child(&self, index: usize) -> Option<&Arc<dyn Node>> {
+        self.children.get(index).and_then(|opt| opt.as_ref())
+    }
+
+    fn add_in_place(dst: &mut [f64], src: &[f64]) {
+        debug_assert_eq!(dst.len(), src.len(), "class_distribution length mismatch");
+        for (d, s) in dst.iter_mut().zip(src.iter()) {
+            *d += *s;
+        }
+    }
+
+    fn instance_child_index(&self, instance: Arc<dyn Instance>) -> Option<usize> {
+        self.split_test.branch_for_instance(instance)
+    }
+}
+
+impl Node for SplitNode {
+    fn get_observed_class_distribution(&self) -> &Vec<f64> {
+        &self.observed_class_distribution
+    }
+
+    fn is_leaf(&self) -> bool {
+        false
+    }
+
+    fn filter_instance_to_leaf<'a>(
+        &'a self,
+        instance: Arc<dyn Instance>,
+        parent: Option<&'a SplitNode>,
+        parent_branch: usize,
+    ) -> FoundNode<'a> {
+        if let Some(child_index) = self.instance_child_index(instance.clone()) {
+            if let Some(child) = self.get_child(child_index) {
+                return child.filter_instance_to_leaf(instance, Some(self), child_index);
+            }
+            return FoundNode::new(None, Some(self), child_index);
+        }
+        FoundNode::new(Some(self), parent, parent_branch)
+    }
+
+    fn get_observed_class_distribution_at_leaves_reachable_through_this_node(&self) -> Vec<f64> {
+        let mut sum_observed_class_distribution_at_leaves =
+            vec![0.0; self.observed_class_distribution.len()];
+        for child_opt in &self.children {
+            if let Some(child) = child_opt.as_ref() {
+                let child_dist =
+                    child.get_observed_class_distribution_at_leaves_reachable_through_this_node();
+                Self::add_in_place(&mut sum_observed_class_distribution_at_leaves, &child_dist)
+            }
+        }
+        sum_observed_class_distribution_at_leaves
+    }
+
+    fn get_class_votes(&self, instance: &dyn Instance, hoeffding_tree: &HoeffdingTree) -> Vec<f64> {
+        self.observed_class_distribution.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::classifiers::hoeffding_tree::instance_conditional_test::InstanceConditionalTest;
+    use crate::classifiers::hoeffding_tree::nodes::InactiveLearningNode;
+    use crate::core::attributes::NominalAttribute;
+    use crate::core::instance_header::InstanceHeader;
+    use crate::core::instances::dense_instance::DenseInstance;
+    use std::sync::Arc;
+
+    struct DummyTest {
+        branch: Option<usize>,
+    }
+
+    impl InstanceConditionalTest for DummyTest {
+        fn branch_for_instance(&self, _instance: Arc<dyn Instance>) -> Option<usize> {
+            self.branch
+        }
+
+        fn result_known_for_instance(&self, _instance: Arc<dyn Instance>) -> bool {
+            self.branch.is_some()
+        }
+
+        fn max_branches(&self) -> usize {
+            2
+        }
+
+        fn get_atts_test_depends_on(&self) -> Vec<usize> {
+            vec![0]
+        }
+    }
+
+    fn make_header() -> Arc<InstanceHeader> {
+        use crate::core::attributes::AttributeRef;
+        use std::collections::HashMap;
+
+        let mut label_to_index1 = HashMap::new();
+        label_to_index1.insert("a".to_string(), 0);
+        label_to_index1.insert("b".to_string(), 1);
+
+        let att1: AttributeRef = Arc::new(NominalAttribute::with_values(
+            "att1".to_string(),
+            vec!["a".to_string(), "b".to_string()],
+            label_to_index1,
+        ));
+
+        let mut label_to_index_class = HashMap::new();
+        label_to_index_class.insert("c0".to_string(), 0);
+        label_to_index_class.insert("c1".to_string(), 1);
+
+        let class_att: AttributeRef = Arc::new(NominalAttribute::with_values(
+            "class".to_string(),
+            vec!["c0".to_string(), "c1".to_string()],
+            label_to_index_class,
+        ));
+
+        let attributes: Vec<AttributeRef> = vec![att1, class_att];
+
+        Arc::new(InstanceHeader::new("relation".to_string(), attributes, 1))
+    }
+
+    fn make_instance(class_value: f64) -> Arc<dyn Instance> {
+        let header = make_header();
+        let mut values = vec![0.0; header.number_of_attributes()];
+        values[header.class_index()] = class_value;
+        Arc::new(DenseInstance::new(header, values, 1.0))
+    }
+
+    #[test]
+    fn test_new_split_node_initializes_children() {
+        let test = Box::new(DummyTest { branch: None });
+        let node = SplitNode::new(test, vec![1.0, 2.0], Some(3));
+        assert_eq!(node.children.len(), 3);
+        assert!(node.children.iter().all(|c| c.is_none()));
+    }
+
+    #[test]
+    fn test_set_and_get_child_with_real_node() {
+        let test = Box::new(DummyTest { branch: Some(0) });
+        let mut node = SplitNode::new(test, vec![1.0, 2.0], Some(1));
+
+        let leaf = Arc::new(InactiveLearningNode::new(vec![5.0, 5.0]));
+        node.set_child(0, leaf.clone());
+
+        let retrieved = node.get_child(0).unwrap();
+        assert_eq!(retrieved.get_observed_class_distribution(), &vec![5.0, 5.0]);
+    }
+
+    #[test]
+    fn test_distribution_sum_with_real_nodes() {
+        let test = Box::new(DummyTest { branch: None });
+        let mut node = SplitNode::new(test, vec![1.0, 2.0], Some(2));
+
+        let leaf1 = Arc::new(InactiveLearningNode::new(vec![2.0, 3.0]));
+        let leaf2 = Arc::new(InactiveLearningNode::new(vec![4.0, 1.0]));
+        node.set_child(0, leaf1);
+        node.set_child(1, leaf2);
+
+        let summed = node.get_observed_class_distribution_at_leaves_reachable_through_this_node();
+        assert_eq!(summed, vec![6.0, 4.0]); // (2+4 , 3+1)
+    }
+
+    #[test]
+    fn test_filter_instance_to_leaf_routes_to_real_node() {
+        let test = Box::new(DummyTest { branch: Some(0) });
+        let mut node = SplitNode::new(test, vec![1.0, 2.0], Some(1));
+
+        let leaf = Arc::new(InactiveLearningNode::new(vec![3.0, 7.0]));
+        node.set_child(0, leaf.clone());
+
+        let inst = make_instance(1.0);
+        let found = node.filter_instance_to_leaf(inst, None, 0);
+
+        assert!(found.get_node().is_some());
+        assert_eq!(
+            found.get_node().unwrap().get_observed_class_distribution(),
+            &vec![3.0, 7.0]
+        );
+    }
+}

--- a/src/tasks/prequential_evaluator.rs
+++ b/src/tasks/prequential_evaluator.rs
@@ -97,10 +97,7 @@ impl PrequentialEvaluator {
             };
             self.processed += 1;
 
-            let votes = self
-                .learner
-                .get_votes_for_instance(&*instance)
-                .unwrap_or_default();
+            let votes = self.learner.get_votes_for_instance(&*instance);
 
             self.evaluator.add_result(&*instance, votes);
 

--- a/src/testing/dummies/classifier_none_votes.rs
+++ b/src/testing/dummies/classifier_none_votes.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 pub struct ClassifierNoneVotes;
 
 impl Classifier for ClassifierNoneVotes {
-    fn get_votes_for_instance(&self, instance: &dyn Instance) -> Option<Vec<f64>> {
-        None
+    fn get_votes_for_instance(&self, instance: &dyn Instance) -> Vec<f64> {
+        Vec::new()
     }
     fn set_model_context(&mut self, header: Arc<InstanceHeader>) {}
     fn train_on_instance(&mut self, instance: Box<dyn Instance>) {}

--- a/src/testing/spies/train_spy_classifier.rs
+++ b/src/testing/spies/train_spy_classifier.rs
@@ -33,13 +33,13 @@ impl TrainSpyClassifier {
 }
 
 impl Classifier for TrainSpyClassifier {
-    fn get_votes_for_instance(&self, inst: &dyn Instance) -> Option<Vec<f64>> {
-        let y = inst.class_value()? as usize;
+    fn get_votes_for_instance(&self, inst: &dyn Instance) -> Vec<f64> {
+        let y = inst.class_value().unwrap_or_default() as usize;
         let mut v = vec![0.0; self.num_classes.max(2)];
         if y < v.len() {
             v[y] = 1.0;
         }
-        Some(v)
+        v
     }
 
     fn set_model_context(&mut self, h: Arc<InstanceHeader>) {

--- a/src/testing/stubs/oracle_classifier.rs
+++ b/src/testing/stubs/oracle_classifier.rs
@@ -10,13 +10,13 @@ pub struct OracleClassifier {
 }
 
 impl Classifier for OracleClassifier {
-    fn get_votes_for_instance(&self, instance: &dyn Instance) -> Option<Vec<f64>> {
-        let y = instance.class_value()? as usize;
+    fn get_votes_for_instance(&self, instance: &dyn Instance) -> Vec<f64> {
+        let y = instance.class_value().unwrap_or_default() as usize;
         let mut v = vec![0.0; self.num_classes.max(2)];
         if y < v.len() {
             v[y] = 1.0;
         }
-        Some(v)
+        v
     }
 
     fn set_model_context(&mut self, header: Arc<InstanceHeader>) {


### PR DESCRIPTION
this commit closes #25 by implementing the Node structure and all it's related structs. The implemented modules were:
- Node
- FoundNode
- SplitNode
- LearningNode
- ActiveLearningNode
- InactiveLearningNode
- LearningNodeNB
- LearningNodeNBAdaptive

Some details to take note about this implementation:

The method filter_instance_to_leaf in SplitNode was implemented using static lifetimes.

Some parts of the hoeffding tree was implemented, due to node methods depending on them.

The new_nominal and new_numeric_class_observer from hoeffding tree were implemented as if the PreparedClassOption from moa were disabled.

Tests of these implementations are not yet implemented, as they depend on the implementation of the HoeffdingTree